### PR TITLE
Default job tab

### DIFF
--- a/src/components/JobItems/JobItem.jsx
+++ b/src/components/JobItems/JobItem.jsx
@@ -18,7 +18,7 @@ import { setCurrentCompany } from '../../store/companies.js';
 
 import './jobItem.scss';
 
-const JobItem = ({ job, showForm, setShowForm }) => {
+const JobItem = ({ job, showForm, setShowForm, setActiveForm }) => {
 
   const dispatch = useDispatch();
 
@@ -45,6 +45,7 @@ const JobItem = ({ job, showForm, setShowForm }) => {
     // update id in job form, then show form
     dispatch(setCurrentJob(job.id));
     dispatch(setCurrentCompany(job.CompanyId));
+    setActiveForm('Job');
     setShowForm(!showForm);
   }
 

--- a/src/components/JobsList/JobsList.jsx
+++ b/src/components/JobsList/JobsList.jsx
@@ -4,7 +4,7 @@ import fuzzysort from 'fuzzysort';
 import JobItem from '../JobItems/JobItem';
 import './jobsList.scss';
 
-const JobsList = ({ showForm, setShowForm, setSelectedJobId, setSelectedCompanyId }) => {
+const JobsList = ({ showForm, setShowForm, setSelectedJobId, setSelectedCompanyId, setActiveForm }) => {
 
 
   const jobState = useSelector(state => state.jobs.jobs);
@@ -81,14 +81,18 @@ const JobsList = ({ showForm, setShowForm, setSelectedJobId, setSelectedCompanyI
                   showForm={showForm}
                   setShowForm={setShowForm}
                   setSelectedJobId={setSelectedJobId}
-                  setSelectedCompanyId={setSelectedCompanyId} /> :
+                  setSelectedCompanyId={setSelectedCompanyId}
+                  setActiveForm={setActiveForm}
+                /> :
                 <JobItem
                   job={job}
                   key={idx}
                   showForm={showForm}
                   setShowForm={setShowForm}
                   setSelectedJobId={setSelectedJobId}
-                  setSelectedCompanyId={setSelectedCompanyId} />
+                  setSelectedCompanyId={setSelectedCompanyId}
+                  setActiveForm={setActiveForm}
+                />
             );
           })
         }

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -76,6 +76,7 @@ const Home = () => {
           selectedJobId={selectedJobId}
           setSelectedJobId={setSelectedJobId}
           selectedCompanyId={selectedCompanyId}
+          setActiveForm={setActiveForm}
           setSelectedCompanyId={setSelectedCompanyId}
           getJobs={getJobs}
           getCompanies={getCompanies} />


### PR DESCRIPTION
This change makes it so when clicking on any job item, the active tab will always be set to the job tab